### PR TITLE
Add try/catches for intentionally removed platform template files

### DIFF
--- a/lib/copyManager.js
+++ b/lib/copyManager.js
@@ -28,6 +28,10 @@ const copyManager = () => {
 
     const removeItem = async item => {
         try {
+            const exists = await fs.pathExists(item);
+            if (!exists) {
+                return;
+            }
             await fs.remove(item);
         } catch (err) {
             console.error(err)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@deg-skeletor/orko",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "The scaffolding tool for the Skeletor UI build tool ecosystem",
     "main": "index.js",
     "scripts": {

--- a/steps/03_installing.js
+++ b/steps/03_installing.js
@@ -29,24 +29,25 @@ const installing = answers => new Promise((resolve, reject) => {
     };
 
     const runSkeletorInstallTask = async () => {
-        const skelConfig = require(`${tmpPath}/${skelInstallName}`);
-        if (!skelConfig) {
+        try {
+            const skelInstallConfig = require(`${tmpPath}/${skelInstallName}`);
+            greet(runningSkeletorInstallTask);
+            await copyManager.move(`${tmpPath}/${skelInstallName}`, `${projectPath}/${skelInstallName}`);
+            const skelCore = require(`${projectPath}/node_modules/@deg-skeletor/core/index.js`)();
+            if (skelCore) {
+                skelCore.setConfig({
+                    tasks: [
+                        skelInstallConfig
+                    ]
+                });
+                await skelCore.runTask('install');
+                greet(skeletorInstallTaskSuccess);
+                return Promise.resolve();
+            }
+            return Promise.reject();
+        } catch (err){
             return Promise.resolve();
         }
-        greet(runningSkeletorInstallTask);
-        await copyManager.move(`${tmpPath}/${skelInstallName}`, `${projectPath}/${skelInstallName}`);
-        const skelCore = require(`${projectPath}/node_modules/@deg-skeletor/core/index.js`)();
-        if (skelCore) {
-            skelCore.setConfig({
-                tasks: [
-                    skelConfig
-                ]
-            });
-            await skelCore.runTask('install');
-            greet(skeletorInstallTaskSuccess);
-            return Promise.resolve();
-        }
-        return Promise.reject();
     };
 
     init();

--- a/steps/03_installing.js
+++ b/steps/03_installing.js
@@ -45,7 +45,7 @@ const installing = answers => new Promise((resolve, reject) => {
                 return Promise.resolve();
             }
             return Promise.reject();
-        } catch (err){
+        } catch {
             return Promise.resolve();
         }
     };


### PR DESCRIPTION
I had to add a try/catch to the attempted `require()` of the skeletor.install.js file, since its absence was throwing an actual error (i.e., I couldn't just do an `if (file)` afterward). Please note: the promise resolution in the `catch` looks weird but is actually correct -- it just means the file wasn't found and Orko can continue without any of the install stuff in the `try`.

I also added a try/catch and `exists()` check for files in the cleanup step, since there are several expected files hardcoded into Orko that may not actually exist in every platform's template files.